### PR TITLE
fixes setting delegate address

### DIFF
--- a/ARKcommander.sh
+++ b/ARKcommander.sh
@@ -80,6 +80,8 @@ LOC_SERVER="http://localhost:4001"
 
 ADDRESS=""
 
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 SNAPDIR="$HOME/snapshots"
 
 re='^[0-9]+$' # For numeric checks
@@ -229,7 +231,6 @@ change_address() {
 
 # Forging Turn
 turn() {
-    DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 #   echo $DIR
 #   echo "$BASH_SOURCE"
 #   echo "$ADDRESS"


### PR DESCRIPTION
the dir variable was being set in the turn() function, which caused it to not be available while setting the delegate address through the submenu, without taking a look at the node stats before that.